### PR TITLE
Add Ruby server

### DIFF
--- a/templates/info.html
+++ b/templates/info.html
@@ -117,6 +117,14 @@
                     <p class="mb-1"><img class="icon" src="/dist/images/brackets.svg" /> <span class="ml-2">Server/Demo</span></p>
                 </a>
             </div>
+            <div class="mt-3 col-sm-12 col-md-6 col-lg-4 d-flex flex-column">
+                <a class="library" href="https://github.com/cedarcode/webauthn-ruby">
+                    <h5>Ruby</h5>
+                    <p class="mb-1"><img class="icon" src="/dist/images/github.svg" /> <span class="ml-2">cedarcode/webauthn-ruby</span></p>
+                    <p class="mb-1"><img class="icon" src="/dist/images/author.svg" /> <span class="ml-2">Gonzalo Rodriguez</span></p>
+                    <p class="mb-1"><img class="icon" src="/dist/images/brackets.svg" /> <span class="ml-2">Server</span></p>
+                </a>
+            </div>
         </div>
     </div>
     <div class="bio-section d-flex flex-wrap section footer-image">


### PR DESCRIPTION
There are no Ruby language libraries in webauthn.io. webauthn-ruby appears to be the _de facto_ based on GitHub metrics/stars