### PR TITLE
Update info.html to fix a typo

### DIFF
--- a/templates/info.html
+++ b/templates/info.html
@@ -14,7 +14,7 @@
                     creation and assertion using a U2F Token, like those provided by Yubico and
                     Feitian, is supported by all of them. The code for this demo can be found
                     <a href="https://github.com/duo-labs/webauthn.io">here on GitHub</a>. To read more about WebAuthn
-                    and what is does, check out
+                    and what it does, check out
                     <a href="https://webauthn.guide">webauthn.guide</a> for an introduction.</p>
                 <div class="row">
                     <div class="col-md-8 col-sm-12">


### PR DESCRIPTION
The typo on the landing page takes away some of the credibility of a security protocol such as WebAuthn