### PR TITLE
login.html: Fix label for select-attestation

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -13,7 +13,7 @@
                             </div>
                             <div class="input-group input-group-lg mb-3">
                                 <div class="input-group-prepend">
-                                    <label class="input-group-text" for="select-authenticator">Attestation Type</label>
+                                    <label class="input-group-text" for="select-attestation">Attestation Type</label>
                                 </div>
                                 <select class="custom-select form-control" id="select-attestation">
                                     <option selected value="none">None</option>


### PR DESCRIPTION
Minor fix `select-authenticator` should be `select-attestation` for the "Attestation Type" label.