### PR TITLE
Add explicit DOCTYPE to the base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,5 @@
 {{define "base"}}
+<!DOCTYPE html>
 <html lang="en">
 
 <head>


### PR DESCRIPTION
Sets DOCTYPE html for HTML5 rendering.

Explicitly specifying DOCTYPE puts browser in standard rendering mode and is recommended by w3c: https://www.w3.org/QA/Tips/Doctype.