### PR TITLE
fix/too-many-allowed-credentials

### DIFF
--- a/_app/homepage/services/authentication.py
+++ b/_app/homepage/services/authentication.py
@@ -61,7 +61,7 @@ class AuthenticationService:
                 PublicKeyCredentialDescriptor(
                     id=base64url_to_bytes(cred.id), transports=cred.transports
                 )
-                for cred in existing_credentials
+                for cred in existing_credentials[-64:]
             ],
         )
 


### PR DESCRIPTION
This PR should fix an issue in Chrome where too many credentials are specified in `allowCredentials` during auth. This can occur when popular usernames, like "test", are used by multiple people to register an unusually high number of credentials.

With this fix only **the 64 most recently registered credentials** will be presented for use during authentication. It's the more naive solution to this problem; let's see for how long I can get away with this.

Fixes #55.