### PR TITLE
feat/user-verification-options

### DIFF
--- a/_app/homepage/forms.py
+++ b/_app/homepage/forms.py
@@ -4,6 +4,14 @@ from django import forms
 class RegistrationOptionsRequestForm(forms.Form):
     username = forms.CharField(required=True, max_length=64)
     require_user_verification = forms.BooleanField(required=False, initial=False)
+    user_verification = forms.ChoiceField(
+        required=True,
+        choices=[
+            ("discouraged", "Discouraged"),
+            ("preferred", "Preferred"),
+            ("required", "Required"),
+        ],
+    )
     attestation = forms.ChoiceField(
         required=True,
         choices=[

--- a/_app/homepage/forms.py
+++ b/_app/homepage/forms.py
@@ -3,7 +3,6 @@ from django import forms
 
 class RegistrationOptionsRequestForm(forms.Form):
     username = forms.CharField(required=True, max_length=64)
-    require_user_verification = forms.BooleanField(required=False, initial=False)
     user_verification = forms.ChoiceField(
         required=True,
         choices=[

--- a/_app/homepage/forms.py
+++ b/_app/homepage/forms.py
@@ -47,6 +47,14 @@ class RegistrationResponseForm(forms.Form):
 class AuthenticationOptionsRequestForm(forms.Form):
     username = forms.CharField(required=False, max_length=64)
     require_user_verification = forms.BooleanField(required=False, initial=False)
+    user_verification = forms.ChoiceField(
+        required=True,
+        choices=[
+            ("discouraged", "Discouraged"),
+            ("preferred", "Preferred"),
+            ("required", "Required"),
+        ],
+    )
 
 
 class AuthenticationResponseForm(forms.Form):

--- a/_app/homepage/forms.py
+++ b/_app/homepage/forms.py
@@ -46,7 +46,6 @@ class RegistrationResponseForm(forms.Form):
 
 class AuthenticationOptionsRequestForm(forms.Form):
     username = forms.CharField(required=False, max_length=64)
-    require_user_verification = forms.BooleanField(required=False, initial=False)
     user_verification = forms.ChoiceField(
         required=True,
         choices=[

--- a/_app/homepage/services/authentication.py
+++ b/_app/homepage/services/authentication.py
@@ -43,17 +43,12 @@ class AuthenticationService:
         self,
         *,
         cache_key: str,
-        require_user_verification: bool,
         user_verification: str,
         existing_credentials: List[WebAuthnCredential],
     ) -> PublicKeyCredentialRequestOptions:
         """
         Generate and store authentication options
         """
-
-        _user_verification = UserVerificationRequirement.DISCOURAGED
-        if require_user_verification:
-            _user_verification = UserVerificationRequirement.REQUIRED
 
         if user_verification == "discouraged":
             _user_verification = UserVerificationRequirement.DISCOURAGED

--- a/_app/homepage/services/authentication.py
+++ b/_app/homepage/services/authentication.py
@@ -44,6 +44,7 @@ class AuthenticationService:
         *,
         cache_key: str,
         require_user_verification: bool,
+        user_verification: str,
         existing_credentials: List[WebAuthnCredential],
     ) -> PublicKeyCredentialRequestOptions:
         """
@@ -52,6 +53,13 @@ class AuthenticationService:
 
         user_verification = UserVerificationRequirement.DISCOURAGED
         if require_user_verification:
+            user_verification = UserVerificationRequirement.REQUIRED
+
+        if user_verification == "discouraged":
+            user_verification = UserVerificationRequirement.DISCOURAGED
+        elif user_verification == "preferred":
+            user_verification = UserVerificationRequirement.PREFERRED
+        elif user_verification == "required":
             user_verification = UserVerificationRequirement.REQUIRED
 
         authentication_options = generate_authentication_options(

--- a/_app/homepage/services/authentication.py
+++ b/_app/homepage/services/authentication.py
@@ -51,20 +51,20 @@ class AuthenticationService:
         Generate and store authentication options
         """
 
-        user_verification = UserVerificationRequirement.DISCOURAGED
+        _user_verification = UserVerificationRequirement.DISCOURAGED
         if require_user_verification:
-            user_verification = UserVerificationRequirement.REQUIRED
+            _user_verification = UserVerificationRequirement.REQUIRED
 
         if user_verification == "discouraged":
-            user_verification = UserVerificationRequirement.DISCOURAGED
+            _user_verification = UserVerificationRequirement.DISCOURAGED
         elif user_verification == "preferred":
-            user_verification = UserVerificationRequirement.PREFERRED
+            _user_verification = UserVerificationRequirement.PREFERRED
         elif user_verification == "required":
-            user_verification = UserVerificationRequirement.REQUIRED
+            _user_verification = UserVerificationRequirement.REQUIRED
 
         authentication_options = generate_authentication_options(
             rp_id=settings.RP_ID,
-            user_verification=user_verification,
+            user_verification=_user_verification,
             allow_credentials=[
                 PublicKeyCredentialDescriptor(
                     id=base64url_to_bytes(cred.id), transports=cred.transports

--- a/_app/homepage/services/registration.py
+++ b/_app/homepage/services/registration.py
@@ -34,6 +34,7 @@ class RegistrationService:
         attestation: str,
         attachment: str,
         require_user_verification: bool,
+        user_verification: str,
         algorithms: List[str],
         existing_credentials: List[WebAuthnCredential],
         discoverable_credential: str,
@@ -55,6 +56,13 @@ class RegistrationService:
             authenticator_selection.authenticator_attachment = authenticator_attachment
 
         if require_user_verification:
+            authenticator_selection.user_verification = UserVerificationRequirement.REQUIRED
+
+        if user_verification == "discouraged":
+            authenticator_selection.user_verification = UserVerificationRequirement.DISCOURAGED
+        elif user_verification == "preferred":
+            authenticator_selection.user_verification = UserVerificationRequirement.PREFERRED
+        elif user_verification == "required":
             authenticator_selection.user_verification = UserVerificationRequirement.REQUIRED
 
         if discoverable_credential == "discouraged":

--- a/_app/homepage/services/registration.py
+++ b/_app/homepage/services/registration.py
@@ -33,7 +33,6 @@ class RegistrationService:
         username: str,
         attestation: str,
         attachment: str,
-        require_user_verification: bool,
         user_verification: str,
         algorithms: List[str],
         existing_credentials: List[WebAuthnCredential],
@@ -54,9 +53,6 @@ class RegistrationService:
                 authenticator_attachment = AuthenticatorAttachment.PLATFORM
 
             authenticator_selection.authenticator_attachment = authenticator_attachment
-
-        if require_user_verification:
-            authenticator_selection.user_verification = UserVerificationRequirement.REQUIRED
 
         if user_verification == "discouraged":
             authenticator_selection.user_verification = UserVerificationRequirement.DISCOURAGED

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -66,7 +66,7 @@
               </p>
 
               <!-- User Verification -->
-              <label for="optRegUserVerification" class="col-6 mb-2">
+              <label for="optRegUserVerification" class="col-md-6 col-sm-12 mb-2">
                 User Verification
                 <br>
                 <select
@@ -86,7 +86,7 @@
               </label>
 
               <!-- Attachment -->
-              <label for="attachment" class="col-6 mb-2">
+              <label for="attachment" class="col-md-6 col-sm-12 mb-2">
                 Attachment
                 <br>
                 <select
@@ -106,7 +106,7 @@
               </label>
 
               <!-- Discoverable Credential -->
-              <label for="discoverableCredential" class="col-7 mb-2">
+              <label for="discoverableCredential" class="col-md-7 col-sm-12 mb-2">
                 Discoverable Credential
                 <br>
                 <select
@@ -126,7 +126,7 @@
               </label>
 
               <!-- Attestation dropdown -->
-              <label for="attestation" class="col-5 mb-2">
+              <label for="attestation" class="col-md-5 col-sm-12 mb-2">
                 Attestation
                 <br />
                 <select
@@ -182,7 +182,7 @@
               </p>
 
               <!-- User Verification -->
-              <label for="optAuthUserVerification" class="col-6 mb-2">
+              <label for="optAuthUserVerification" class="col-md-6 col-sm-12 mb-2">
                 User Verification
                 <br>
                 <select

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -200,22 +200,6 @@
                   </template>
                 </select>
               </label>
-
-              <section class="col-12 mb-2">
-                <!-- User Verification -->
-                <div class="custom-control custom-checkbox custom-control-inline">
-                  <input
-                    type="checkbox"
-                    name="optAuthRequireUV"
-                    id="optAuthRequireUV"
-                    class="custom-control-input"
-                    x-model="options.authRequireUserVerification"
-                  />
-                  <label for="optAuthRequireUV" class="custom-control-label">
-                    Require User Verification
-                  </label>
-                </div>
-              </section>
             </div>
 
             <div class="row">
@@ -307,9 +291,6 @@
           /**
            * Authentication Settings
            */
-           this.options.authRequireUserVerification =
-            currentParams.get('authRequireUserVerification') === 'true';
-
           const _authUserVerification = currentParams.get('authUserVerification');
           for (const uv of this.userVerificationOpts) {
             if (uv.value === _authUserVerification) {
@@ -355,7 +336,6 @@
         algRS256: true,
         discoverableCredential: 'preferred',
         // Authentication
-        authRequireUserVerification: true,
         authUserVerification: 'preferred',
       },
       username: '',
@@ -498,7 +478,6 @@
       },
       async _startAuthentication(startConditionalUI = false) {
         const {
-          authRequireUserVerification,
           authUserVerification,
         } = this.options;
 
@@ -508,7 +487,6 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             username: this.username,
-            require_user_verification: authRequireUserVerification,
             user_verification: authUserVerification,
           }),
         });

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -65,6 +65,26 @@
                 <ins>Registration Settings</ins>
               </p>
 
+              <!-- User Verification -->
+              <label for="optRegUserVerification" class="col-6 mb-2">
+                User Verification
+                <br>
+                <select
+                  name="optRegUserVerification"
+                  id="optRegUserVerification"
+                  class="custom-select"
+                  x-model="options.regUserVerification"
+                >
+                  <template x-for="option in userVerificationOpts" :key="option.value">
+                    <option
+                      :value="option.value"
+                      :selected="options.regUserVerification === option.value"
+                      x-text="option.label"
+                    ></option>
+                  </template>
+                </select>
+              </label>
+
               <!-- Attachment -->
               <label for="attachment" class="col-6 mb-2">
                 Attachment
@@ -80,26 +100,6 @@
                       :value="attachment.value"
                       :selected="options.attachment === attachment.value"
                       x-text="attachment.label"
-                    ></option>
-                  </template>
-                </select>
-              </label>
-
-              <!-- Discoverable Credential -->
-              <label for="optRegUserVerification" class="col-6 mb-2">
-                User Verification
-                <br>
-                <select
-                  name="optRegUserVerification"
-                  id="optRegUserVerification"
-                  class="custom-select"
-                  x-model="options.regUserVerification"
-                >
-                  <template x-for="option in userVerificationOpts" :key="option.value">
-                    <option
-                      :value="option.value"
-                      :selected="options.regUserVerification === option.value"
-                      x-text="option.label"
                     ></option>
                   </template>
                 </select>

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -249,8 +249,6 @@
           /**
            * Registration Settings
            */
-          this.options.regRequireUserVerification =
-            currentParams.get('regRequireUserVerification') === 'true';
           this.options.algES256 = currentParams.get('algES256') === 'true';
           this.options.algRS256 = currentParams.get('algRS256') === 'true';
 
@@ -322,7 +320,6 @@
       formAction: 'registration',
       options: {
         // Registration
-        regRequireUserVerification: true,
         regUserVerification: 'preferred',
         attestation: 'none',
         attachment: 'all',
@@ -407,7 +404,6 @@
       async _startRegistration() {
         // Submit options
         const {
-          regRequireUserVerification,
           regUserVerification,
           algES256,
           algRS256,
@@ -436,8 +432,6 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             username: this.username,
-            // e.g. true
-            require_user_verification: regRequireUserVerification,
             // e.g. 'preferred'
             user_verification: regUserVerification,
             // e.g. 'direct'

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -270,6 +270,14 @@
           this.options.algES256 = currentParams.get('algES256') === 'true';
           this.options.algRS256 = currentParams.get('algRS256') === 'true';
 
+          const _regUserVerification = currentParams.get('regUserVerification');
+          for (const uv of this.userVerificationOpts) {
+            if (uv.value === _regUserVerification) {
+              this.options.regUserVerification = _regUserVerification;
+              break;
+            }
+          }
+
           const _attestation = currentParams.get('attestation');
           for (const attestation of this.attestations) {
             if (attestation.value === _attestation) {
@@ -416,6 +424,7 @@
         // Submit options
         const {
           regRequireUserVerification,
+          regUserVerification,
           algES256,
           algRS256,
           attestation,
@@ -445,6 +454,8 @@
             username: this.username,
             // e.g. true
             require_user_verification: regRequireUserVerification,
+            // e.g. 'preferred'
+            user_verification: regUserVerification,
             // e.g. 'direct'
             attestation,
             // e.g. 'platform'

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -112,8 +112,8 @@
               </section>
 
               <!-- Attachment -->
-              <label for="attachment" class="col-7 mb-2">
-                Authenticator Attachment
+              <label for="attachment" class="col-6 mb-2">
+                Attachment
                 <br>
                 <select
                   name="attachment"
@@ -131,21 +131,21 @@
                 </select>
               </label>
 
-              <!-- Attestation dropdown -->
-              <label for="attestation" class="col-5 mb-2">
-                Attestation
-                <br />
+              <!-- Discoverable Credential -->
+              <label for="optRegUserVerification" class="col-6 mb-2">
+                User Verification
+                <br>
                 <select
-                  name="attestation"
-                  id="attestation"
+                  name="optRegUserVerification"
+                  id="optRegUserVerification"
                   class="custom-select"
-                  x-model="options.attestation"
+                  x-model="options.regUserVerification"
                 >
-                  <template x-for="attestation in attestations" :key="attestation.value">
+                  <template x-for="option in userVerificationOpts" :key="option.value">
                     <option
-                      :value="attestation.value"
-                      :selected="options.attestation === attestation.value"
-                      x-text="attestation.label"
+                      :value="option.value"
+                      :selected="options.regUserVerification === option.value"
+                      x-text="option.label"
                     ></option>
                   </template>
                 </select>
@@ -166,6 +166,26 @@
                       :value="option.value"
                       :selected="options.discoverableCredential === option.value"
                       x-text="option.label"
+                    ></option>
+                  </template>
+                </select>
+              </label>
+
+              <!-- Attestation dropdown -->
+              <label for="attestation" class="col-5 mb-2">
+                Attestation
+                <br />
+                <select
+                  name="attestation"
+                  id="attestation"
+                  class="custom-select"
+                  x-model="options.attestation"
+                >
+                  <template x-for="attestation in attestations" :key="attestation.value">
+                    <option
+                      :value="attestation.value"
+                      :selected="options.attestation === attestation.value"
+                      x-text="attestation.label"
                     ></option>
                   </template>
                 </select>

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -181,6 +181,26 @@
                 <ins>Authentication Settings</ins>
               </p>
 
+              <!-- User Verification -->
+              <label for="optAuthUserVerification" class="col-6 mb-2">
+                User Verification
+                <br>
+                <select
+                  name="optAuthUserVerification"
+                  id="optAuthUserVerification"
+                  class="custom-select"
+                  x-model="options.authUserVerification"
+                >
+                  <template x-for="option in userVerificationOpts" :key="option.value">
+                    <option
+                      :value="option.value"
+                      :selected="options.authUserVerification === option.value"
+                      x-text="option.label"
+                    ></option>
+                  </template>
+                </select>
+              </label>
+
               <section class="col-12 mb-2">
                 <!-- User Verification -->
                 <div class="custom-control custom-checkbox custom-control-inline">
@@ -289,6 +309,14 @@
            */
            this.options.authRequireUserVerification =
             currentParams.get('authRequireUserVerification') === 'true';
+
+          const _authUserVerification = currentParams.get('authUserVerification');
+          for (const uv of this.userVerificationOpts) {
+            if (uv.value === _authUserVerification) {
+              this.options.authUserVerification = _authUserVerification;
+              break;
+            }
+          }
         }
 
         // Update query parameters when options change
@@ -328,6 +356,7 @@
         discoverableCredential: 'preferred',
         // Authentication
         authRequireUserVerification: true,
+        authUserVerification: 'preferred',
       },
       username: '',
       alert: {
@@ -335,7 +364,7 @@
         alertClass: 'alert alert-success',
         text: '',
       },
-      // Possible values for options.userVerification
+      // Possible values for options.regUserVerification and options.authUserVerification
       userVerificationOpts: [
         { label: 'Discouraged', value: 'discouraged' },
         { label: 'Preferred', value: 'preferred' },
@@ -470,6 +499,7 @@
       async _startAuthentication(startConditionalUI = false) {
         const {
           authRequireUserVerification,
+          authUserVerification,
         } = this.options;
 
         // Submit options
@@ -479,6 +509,7 @@
           body: JSON.stringify({
             username: this.username,
             require_user_verification: authRequireUserVerification,
+            user_verification: authUserVerification,
           }),
         });
         const authenticationOptionsJSON = await apiAuthOptsResp.json();

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -311,6 +311,7 @@
       options: {
         // Registration
         regRequireUserVerification: true,
+        regUserVerification: 'preferred',
         attestation: 'none',
         attachment: 'all',
         algES256: true,
@@ -325,6 +326,12 @@
         alertClass: 'alert alert-success',
         text: '',
       },
+      // Possible values for options.userVerification
+      userVerificationOpts: [
+        { label: 'Discouraged', value: 'discouraged' },
+        { label: 'Preferred', value: 'preferred' },
+        { label: 'Required', value: 'required' },
+      ],
       // Possible values for options.attestation
       attestations: [
         { label: 'None', value: 'none' },

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -65,52 +65,6 @@
                 <ins>Registration Settings</ins>
               </p>
 
-              <section class="col-12 mb-2">
-                <!-- User Verification -->
-                <div class="custom-control custom-checkbox custom-control-inline">
-                  <input
-                    type="checkbox"
-                    name="optRegRequireUV"
-                    id="optRegRequireUV"
-                    class="custom-control-input"
-                    x-model="options.regRequireUserVerification"
-                  />
-                  <label for="optRegRequireUV" class="custom-control-label">
-                    Require User Verification
-                  </label>
-                </div>
-
-                <br>
-
-                <!-- Algorithm - ES256 -->
-                <div class="custom-control custom-checkbox custom-control-inline">
-                  <input
-                    type="checkbox"
-                    name="optAlgES256"
-                    id="optAlgES256"
-                    class="custom-control-input"
-                    x-model="options.algES256"
-                  />
-                  <label for="optAlgES256" class="custom-control-label">
-                    Support ES256
-                  </label>
-                </div>
-
-                <!-- Algorithm - RS256 -->
-                <div class="custom-control custom-checkbox custom-control-inline">
-                  <input
-                    type="checkbox"
-                    name="optAlgRS256"
-                    id="optAlgRS256"
-                    class="custom-control-input"
-                    x-model="options.algRS256"
-                  />
-                  <label for="optAlgRS256" class="custom-control-label">
-                    Support RS256
-                  </label>
-                </div>
-              </section>
-
               <!-- Attachment -->
               <label for="attachment" class="col-6 mb-2">
                 Attachment
@@ -190,6 +144,36 @@
                   </template>
                 </select>
               </label>
+
+              <section class="col-12 mb-2">
+                <!-- Algorithm - ES256 -->
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    name="optAlgES256"
+                    id="optAlgES256"
+                    class="custom-control-input"
+                    x-model="options.algES256"
+                  />
+                  <label for="optAlgES256" class="custom-control-label">
+                    Support ES256
+                  </label>
+                </div>
+
+                <!-- Algorithm - RS256 -->
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    name="optAlgRS256"
+                    id="optAlgRS256"
+                    class="custom-control-input"
+                    x-model="options.algRS256"
+                  />
+                  <label for="optAlgRS256" class="custom-control-label">
+                    Support RS256
+                  </label>
+                </div>
+              </section>
             </div>
 
             <div class="row">

--- a/_app/homepage/views/authentication_options.py
+++ b/_app/homepage/views/authentication_options.py
@@ -21,6 +21,7 @@ def authentication_options(request: HttpRequest) -> JsonResponse:
     form_data = options_form.cleaned_data
     options_username: str | None = form_data["username"]
     options_require_user_verification = form_data["require_user_verification"]
+    options_user_verification = form_data["user_verification"]
 
     authentication_service = AuthenticationService()
     session_service = SessionService()
@@ -38,6 +39,7 @@ def authentication_options(request: HttpRequest) -> JsonResponse:
     authentication_options = authentication_service.generate_authentication_options(
         cache_key=session_service.get_session_key(request=request),
         require_user_verification=options_require_user_verification,
+        user_verification=options_user_verification,
         existing_credentials=existing_credentials,
     )
 

--- a/_app/homepage/views/authentication_options.py
+++ b/_app/homepage/views/authentication_options.py
@@ -20,7 +20,6 @@ def authentication_options(request: HttpRequest) -> JsonResponse:
 
     form_data = options_form.cleaned_data
     options_username: str | None = form_data["username"]
-    options_require_user_verification = form_data["require_user_verification"]
     options_user_verification = form_data["user_verification"]
 
     authentication_service = AuthenticationService()
@@ -38,7 +37,6 @@ def authentication_options(request: HttpRequest) -> JsonResponse:
 
     authentication_options = authentication_service.generate_authentication_options(
         cache_key=session_service.get_session_key(request=request),
-        require_user_verification=options_require_user_verification,
         user_verification=options_user_verification,
         existing_credentials=existing_credentials,
     )

--- a/_app/homepage/views/registration_options.py
+++ b/_app/homepage/views/registration_options.py
@@ -26,6 +26,7 @@ def registration_options(request: HttpRequest) -> JsonResponse:
     options_attestation = form_data["attestation"]
     options_attachment = form_data["attachment"]
     options_require_user_verification = form_data["require_user_verification"]
+    options_user_verification = form_data["user_verification"]
     options_algorithms = form_data["algorithms"]
     options_username = form_data["username"]
     options_discoverable_credential = form_data["discoverable_credential"]
@@ -39,6 +40,7 @@ def registration_options(request: HttpRequest) -> JsonResponse:
         attestation=options_attestation,
         algorithms=options_algorithms,
         require_user_verification=options_require_user_verification,
+        user_verification=options_user_verification,
         existing_credentials=credential_service.retrieve_credentials_by_username(
             username=options_username
         ),

--- a/_app/homepage/views/registration_options.py
+++ b/_app/homepage/views/registration_options.py
@@ -25,7 +25,6 @@ def registration_options(request: HttpRequest) -> JsonResponse:
     form_data = options_form.cleaned_data
     options_attestation = form_data["attestation"]
     options_attachment = form_data["attachment"]
-    options_require_user_verification = form_data["require_user_verification"]
     options_user_verification = form_data["user_verification"]
     options_algorithms = form_data["algorithms"]
     options_username = form_data["username"]
@@ -39,7 +38,6 @@ def registration_options(request: HttpRequest) -> JsonResponse:
         attachment=options_attachment,
         attestation=options_attestation,
         algorithms=options_algorithms,
-        require_user_verification=options_require_user_verification,
         user_verification=options_user_verification,
         existing_credentials=credential_service.retrieve_credentials_by_username(
             username=options_username


### PR DESCRIPTION
This PR adds in the ability to select a specific UserVerificationRequirement for registration and authentication. This makes it possible to, for example, test out how authenticators react when they experience the `"preferred"` option.

![Screenshot 2023-01-18 at 12 47 33 PM](https://user-images.githubusercontent.com/5166470/213292669-6768935f-5d8a-48c5-9d66-46a0873d5521.png)

![Screenshot 2023-01-18 at 12 51 11 PM](https://user-images.githubusercontent.com/5166470/213292685-24f57328-eeea-46fd-9688-1432832c8104.png)


Advanced settings have also been made responsive:

![Screenshot 2023-01-18 at 12 47 53 PM](https://user-images.githubusercontent.com/5166470/213292655-22043288-1e5c-4860-9d19-69d584104f27.png)

Fixes #76.