### PR TITLE
fix/clarify-credential-description

### DIFF
--- a/_app/homepage/views/index.py
+++ b/_app/homepage/views/index.py
@@ -34,10 +34,10 @@ def index(request):
             if cred.device_type == "single_device":
                 description += "single-device "
 
-            if not cred.is_discoverable_credential:
-                description += "non-discoverable "
-
-            description += "passkey"
+            if cred.is_discoverable_credential:
+                description += "passkey"
+            else:
+                description += "non-discoverable credential"
 
             parsed_credentials.append(
                 {


### PR DESCRIPTION
This PR clarifies a credential's description, to only call a credential a "passkey" when it is a _discoverable credential_. Non-discoverable credentials will now simply be called "credentials":

![Screenshot 2023-01-18 at 1 08 24 PM](https://user-images.githubusercontent.com/5166470/213295716-c9bca54e-47d8-40d1-ac8d-61ba10a49a79.png)

Fixes #73.