### PR TITLE
fix/82-accessibility-aria-live

### DIFF
--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -20,6 +20,7 @@
               <div
                 :class="alert.alertClass"
                 x-text="alert.text"
+                aria-live="polite"
               ></div>
             </div>
           </template>


### PR DESCRIPTION
This PR adds the `aria-live` attribute to the alerts that appear under the username input box. This should help screen readers communicate alerts to users.

Fixes #82.

## Screenshots

I tested with macOS' VoiceOver and did observe that alerts started getting read when I added this attribute:

![Screenshot 2023-03-01 at 12 17 12 PM](https://user-images.githubusercontent.com/5166470/222256119-d161f213-94e1-4f60-b90f-8486ea3f2f44.png)

![Screenshot 2023-03-01 at 12 17 04 PM](https://user-images.githubusercontent.com/5166470/222256127-ddaa64db-5aa9-4e37-91b3-1e5c9803973f.png)

![Screenshot 2023-03-01 at 12 16 47 PM](https://user-images.githubusercontent.com/5166470/222256132-401219bb-5108-4774-b89c-e2b8598ba4a9.png)
