### PR TITLE
87-rename-single-device-passkey

### DIFF
--- a/_app/homepage/views/index.py
+++ b/_app/homepage/views/index.py
@@ -32,7 +32,7 @@ def index(request):
             description = ""
 
             if cred.device_type == "single_device":
-                description += "single-device "
+                description += "device-bound "
 
             if cred.is_discoverable_credential:
                 description += "passkey"


### PR DESCRIPTION
This PR changes "single-device passkey" labeling to say "device-bound passkey":

![Screenshot 2023-05-09 at 5 13 21 PM](https://github.com/duo-labs/webauthn.io/assets/5166470/1ad0285e-8182-4e28-bd1a-832fcf71d934)

Fixes #87.