### PR TITLE
Provider metadata

### DIFF
--- a/_app/homepage/models.py
+++ b/_app/homepage/models.py
@@ -34,3 +34,5 @@ class WebAuthnCredential(BaseModel):
     device_type: CredentialDeviceType
     backed_up: bool
     transports: Optional[List[AuthenticatorTransport]]
+    # TODO: Clear this at some point point in the future when we know we're setting it
+    aaguid: str = ""

--- a/_app/homepage/services/__init__.py
+++ b/_app/homepage/services/__init__.py
@@ -3,3 +3,4 @@ from .registration import RegistrationService  # noqa: F401
 from .credential import CredentialService  # noqa: F401
 from .authentication import AuthenticationService  # noqa: F401
 from .session import SessionService  # noqa: F401
+from .metadata import MetadataService  # noqa: F401

--- a/_app/homepage/services/credential.py
+++ b/_app/homepage/services/credential.py
@@ -45,6 +45,7 @@ class CredentialService:
             is_discoverable_credential=is_discoverable_credential,
             device_type=verification.credential_device_type,
             backed_up=verification.credential_backed_up,
+            aaguid=verification.aaguid,
         )
 
         self._temporarily_store_in_redis(new_credential)

--- a/_app/homepage/services/metadata.py
+++ b/_app/homepage/services/metadata.py
@@ -1,0 +1,46 @@
+from webauthn.helpers.structs import CredentialDeviceType
+
+
+class MetadataService:
+    # Pulled from https://github.com/passkeydeveloper/passkey-authenticator-aaguids/ on 2023-09-28
+    aaguid_json = {
+        "ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4": {"name": "Google Password Manager"},
+        "adce0002-35bc-c60a-648b-0b25f1f05503": {"name": "Chrome on Mac"},
+        "08987058-cadc-4b81-b6e1-30de50dcbe96": {"name": "Windows Hello"},
+        "9ddd1817-af5a-4672-a2b9-3e3dd95000a9": {"name": "Windows Hello"},
+        "6028b017-b1d4-4c02-b4b3-afcdafc96bb2": {"name": "Windows Hello"},
+        "dd4ec289-e01d-41c9-bb89-70fa845d4bf2": {"name": "Apple iCloud Keychain (Managed)"},
+        "531126d6-e717-415c-9320-3d9aa6981239": {"name": "Dashlane"},
+        "bada5566-a7aa-401f-bd96-45619a55120d": {"name": "1Password"},
+        "b84e4048-15dc-4dd0-8640-f4f60813c8af": {"name": "NordPass"},
+        "0ea242b4-43c4-4a1b-8b17-dd6d0b6baec6": {"name": "Keeper"},
+        "f3809540-7f14-49c1-a8b3-8f813b225541": {"name": "Enpass"},
+        "b5397666-4885-aa6b-cebf-e52262a439a2": {"name": "Chromium Browser"},
+        "771b48fd-d3d4-4f74-9232-fc157ab0507a": {"name": "Edge on Mac"},
+    }
+
+    def get_provider_name(self, *, aaguid: str, device_type: CredentialDeviceType) -> str:
+        """
+        Try to map the provided AAGUID to a human-friendly provider name
+        """
+        default_name = ""
+
+        if not aaguid:
+            return default_name
+
+        provider_metadata = self.aaguid_json.get(aaguid, {})
+        provider_name = provider_metadata.get("name", None)
+
+        # Return the name if we could look one up
+        if provider_name is not None:
+            return provider_name
+
+        # Try to derive the provider name
+        if (
+            aaguid == "00000000-0000-0000-0000-000000000000"
+            and device_type == CredentialDeviceType.MULTI_DEVICE
+        ):
+            return "iCloud Keychain"
+
+        # When all else fails, provide a default name
+        return default_name

--- a/_app/homepage/templates/homepage/profile.html
+++ b/_app/homepage/templates/homepage/profile.html
@@ -71,6 +71,7 @@
             <strong>Description:</strong>
             <br>
             {{ cred.description }}
+            {% if cred.provider_name %}({{ cred.provider_name }}){% endif %}
           </li>
           <li>
             <strong>Transports:</strong>

--- a/_app/homepage/templates/homepage/profile.html
+++ b/_app/homepage/templates/homepage/profile.html
@@ -78,6 +78,11 @@
             <br>
             {{ cred.transports }}
           </li>
+          <li>
+            <strong>AAGUID:</strong>
+            <br>
+            {{ cred.aaguid }}
+          </li>
           <li class="credential-delete">
             <form action="{% url 'credential-delete' cred.raw_id %}" method="post">
               {% csrf_token %}

--- a/_app/homepage/views/index.py
+++ b/_app/homepage/views/index.py
@@ -2,7 +2,8 @@ from django.shortcuts import render
 from webauthn.helpers.structs import CredentialDeviceType
 
 from homepage.const import libraries, demos
-from homepage.services import SessionService, CredentialService
+from homepage.logging import logger
+from homepage.services import SessionService, CredentialService, MetadataService
 from homepage.helpers import transports_to_ui_string, truncate_credential_id_to_ui_string
 
 
@@ -24,6 +25,7 @@ def index(request):
 
         username = request.session["username"]
         credential_service = CredentialService()
+        metadata_service = MetadataService()
 
         user_credentials = credential_service.retrieve_credentials_by_username(username=username)
 
@@ -45,12 +47,18 @@ def index(request):
             else:
                 description += "non-discoverable credential"
 
+            provider_name = metadata_service.get_provider_name(
+                aaguid=str(cred.aaguid),
+                device_type=cred.device_type,
+            )
+
             parsed_credentials.append(
                 {
                     "id": truncate_credential_id_to_ui_string(cred.id),
                     "raw_id": cred.id,
                     "transports": transports_to_ui_string(cred.transports or []),
                     "description": description,
+                    "provider_name": provider_name,
                 }
             )
 

--- a/_app/homepage/views/index.py
+++ b/_app/homepage/views/index.py
@@ -47,8 +47,9 @@ def index(request):
             else:
                 description += "non-discoverable credential"
 
+            aaguid = str(cred.aaguid)
             provider_name = metadata_service.get_provider_name(
-                aaguid=str(cred.aaguid),
+                aaguid=aaguid,
                 device_type=cred.device_type,
             )
 
@@ -59,7 +60,7 @@ def index(request):
                     "transports": transports_to_ui_string(cred.transports or []),
                     "description": description,
                     "provider_name": provider_name,
-                    "aaguid": str(cred.aaguid),
+                    "aaguid": aaguid,
                 }
             )
 

--- a/_app/homepage/views/index.py
+++ b/_app/homepage/views/index.py
@@ -59,6 +59,7 @@ def index(request):
                     "transports": transports_to_ui_string(cred.transports or []),
                     "description": description,
                     "provider_name": provider_name,
+                    "aaguid": str(cred.aaguid),
                 }
             )
 


### PR DESCRIPTION
This PR adds a basic attempt to name the credential provider:

![Screenshot 2023-09-28 at 4 32 05 PM](https://github.com/duo-labs/webauthn.io/assets/5166470/d81e92f1-015c-4683-88cd-4b0c6bdfe9df)

I'll periodically update this logic as more synced passkey aaguids become known. Security key identification may come later when I have more time.