### PR TITLE
feat/registration-hints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,9 @@
 {
-  "python.linting.enabled": true,
-  "python.linting.lintOnSave": true,
-  "python.linting.flake8Enabled": true,
-  "python.linting.mypyEnabled": true,
-  "python.formatting.provider": "black",
-  "python.formatting.blackArgs": [
+  "black-formatter.args": [
     "--line-length", "99"
   ],
   "[python]": {
-    "editor.defaultFormatter": "ms-python.python",
+    "editor.defaultFormatter": "ms-python.black-formatter",
     "editor.formatOnPaste": false,
     "editor.formatOnSaveMode": "file",
     "editor.formatOnSave": true

--- a/_app/gunicorn.cfg.py
+++ b/_app/gunicorn.cfg.py
@@ -1,5 +1,16 @@
 import multiprocessing
+import os
+
+from homepage.logging import logger
 
 bind = ":8000"
-workers = multiprocessing.cpu_count() * 2 + 1
 errorlog = "gunicorn_webauthnio.log"
+
+DEBUG = os.getenv("DEBUG", False)
+
+if DEBUG == "true":
+    workers = 1
+else:
+    workers = multiprocessing.cpu_count() * 2 + 1
+
+logger.info(f"Gunicorn will use {workers} worker(s)")

--- a/_app/homepage/forms.py
+++ b/_app/homepage/forms.py
@@ -37,6 +37,14 @@ class RegistrationOptionsRequestForm(forms.Form):
             ("required", "Required"),
         ],
     )
+    hints = forms.MultipleChoiceField(
+        required=False,
+        choices=[
+            ("security-key", "Security Key"),
+            ("client-device", "Client Device"),
+            ("hybrid", "Hybrid"),
+        ],
+    )
 
 
 class RegistrationResponseForm(forms.Form):

--- a/_app/homepage/services/registration.py
+++ b/_app/homepage/services/registration.py
@@ -37,6 +37,7 @@ class RegistrationService:
         algorithms: List[str],
         existing_credentials: List[WebAuthnCredential],
         discoverable_credential: str,
+        hints: List[str],
     ):
         _attestation = AttestationConveyancePreference.NONE
 
@@ -47,7 +48,28 @@ class RegistrationService:
             user_verification=UserVerificationRequirement.DISCOURAGED,
             resident_key=ResidentKeyRequirement.PREFERRED,
         )
-        if attachment != "all":
+        if len(hints) > 0:
+            """
+            Deferring to hints when present as per https://w3c.github.io/webauthn/#enum-hints
+            """
+            if hints[0] == "security-key":
+                # "For compatibility with older user agents, when this hint is used in
+                # PublicKeyCredentialCreationOptions, the authenticatorAttachment SHOULD be set to
+                # cross-platform."
+                authenticator_attachment = AuthenticatorAttachment.CROSS_PLATFORM
+            elif hints[0] == "hybrid":
+                # "For compatibility with older user agents, when this hint is used in
+                # PublicKeyCredentialCreationOptions, the authenticatorAttachment SHOULD be set to
+                # cross-platform."
+                authenticator_attachment = AuthenticatorAttachment.CROSS_PLATFORM
+            elif hints[0] == "client-device":
+                # "For compatibility with older user agents, when this hint is used in
+                # PublicKeyCredentialCreationOptions, the authenticatorAttachment SHOULD be set to
+                # platform."
+                authenticator_attachment = AuthenticatorAttachment.PLATFORM
+
+            authenticator_selection.authenticator_attachment = authenticator_attachment
+        elif attachment != "all":
             authenticator_attachment = AuthenticatorAttachment.CROSS_PLATFORM
             if attachment == "platform":
                 authenticator_attachment = AuthenticatorAttachment.PLATFORM

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -179,7 +179,7 @@
 
               <!-- Registration Hints -->
               <section class="col-sm-12 mb-2">
-                <p class="mb-0">Registration Hints</p>
+                <p class="mb-0">Registration Hints (most to least preferred)</p>
                 <div class="custom-control custom-checkbox custom-control-inline">
                   <input
                     type="checkbox"

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -176,6 +176,51 @@
                   </label>
                 </div>
               </section>
+
+              <!-- Registration Hints -->
+              <section class="col-sm-12 mb-2">
+                <p class="mb-0">Registration Hints</p>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    class="custom-control-input"
+                    id="regHintSecurityKey"
+                    x-model="_regHints.securityKey"
+                    @change="handleSelectRegHintsSecurityKey"
+                  />
+                  <label class="custom-control-label" for="regHintSecurityKey">
+                    Security Key
+                  </label>
+                </div>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    class="custom-control-input"
+                    id="regHintClientDevice"
+                    x-model="_regHints.clientDevice"
+                    @change="handleSelectRegHintsClientDevice"
+                  />
+                  <label class="custom-control-label" for="regHintClientDevice">
+                    Client Device
+                  </label>
+                </div>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    class="custom-control-input"
+                    id="regHintHybrid"
+                    x-model="_regHints.hybrid"
+                    @change="handleSelectRegHintsHybrid"
+                  />
+                  <label class="custom-control-label" for="regHintHybrid">
+                    Hybrid
+                  </label>
+                </div>
+                <p class="mb-0 text-secondary">
+                  Order:
+                  <span x-text="_regHints.formatted"></span>
+                </p>
+              </section>
             </div>
 
             <div class="row">

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -497,6 +497,7 @@
           attestation,
           attachment,
           discoverableCredential,
+          regHints,
         } = this.options;
 
         const algorithms = [];
@@ -529,6 +530,8 @@
             algorithms,
             // e.g. 'preferred'
             discoverable_credential: discoverableCredential,
+            // e.g. ['security-key', 'hybrid']
+            hints: regHints,
           }),
         });
         const registrationOptionsJSON = await apiRegOptsResp.json();

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -147,6 +147,7 @@
               </label>
 
               <section class="col-12 mb-2">
+                <p class="mb-0">Public Key Algorithms</p>
                 <!-- Algorithm - ES256 -->
                 <div class="custom-control custom-checkbox custom-control-inline">
                   <input

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -357,6 +357,17 @@
           );
         });
 
+        /**
+         * Format the list of registration hints to help confirm the order of preference
+         */
+        this.$watch('options.regHints', () => {
+          let formattedHints = JSON.stringify(this.options.regHints);
+          // Add a space between items
+          formattedHints = formattedHints.replace(/,/g, ", ");
+
+          this._regHints.formatted = formattedHints;
+        });
+
         // Set up Conditional UI if supported
         browserSupportsWebAuthnAutofill().then(async (supported) => {
           if (supported) {

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -59,7 +59,7 @@
           Advanced Settings
         </button>
 
-        <div class="card container settings-drawer" x-cloak x-show="showAdvancedSettings">
+        <div class="card container settings-drawer pb-0" x-cloak x-show="showAdvancedSettings">
           <div class="card-body">
             <div class="row">
               <p class="col-12 px-0 mb-1">

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -568,12 +568,18 @@
           authUserVerification,
         } = this.options;
 
+        let username = this.username;
+        if (startConditionalUI) {
+          // We won't have a username for conditional UI
+          username = undefined;
+        }
+
         // Submit options
         const apiAuthOptsResp = await fetch('{% url "authentication-options" %}', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            username: this.username,
+            username,
             user_verification: authUserVerification,
           }),
         });

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -418,6 +418,7 @@
         alertClass: 'alert alert-success',
         text: '',
       },
+      // We need to track some state to properly support hints preference order
       _regHints: {
         securityKey: false,
         clientDevice: false,

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -376,11 +376,7 @@
          * Format the list of registration hints to help confirm the order of preference
          */
         this.$watch('options.regHints', () => {
-          let formattedHints = JSON.stringify(this.options.regHints);
-          // Add a space between items
-          formattedHints = formattedHints.replace(/,/g, ", ");
-
-          this._regHints.formatted = formattedHints;
+          this._formatRegHintsForUI();
         });
 
         // Set up Conditional UI if supported
@@ -651,6 +647,16 @@
           }
         }
       },
+      /**
+       * Format registration hints so we can visualize their preference order
+       */
+      _formatRegHintsForUI() {
+        let formattedHints = JSON.stringify(this.options.regHints);
+        // Add a space between items
+        formattedHints = formattedHints.replace(/,/g, ", ");
+
+        this._regHints.formatted = formattedHints;
+      }
     }));
   });
 </script>

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -335,6 +335,21 @@
             }
           }
 
+          const _regHintsStr = currentParams.get('regHints');
+          _regHintsStr.split(',').forEach((hint) => {
+            if (hint === 'security-key') {
+              this._regHints.securityKey = true;
+              this._toggleRegHint('security-key', true);
+            } else if (hint === 'client-device') {
+              this._regHints.clientDevice = true;
+              this._toggleRegHint('client-device', true);
+            } else if (hint === 'hybrid') {
+              this._regHints.hybrid = true;
+              this._toggleRegHint('hybrid', true);
+            }
+          });
+          this._formatRegHintsForUI();
+
           /**
            * Authentication Settings
            */

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -386,6 +386,7 @@
         algES256: true,
         algRS256: true,
         discoverableCredential: 'preferred',
+        regHints: [],
         // Authentication
         authUserVerification: 'preferred',
       },
@@ -394,6 +395,12 @@
         show: false,
         alertClass: 'alert alert-success',
         text: '',
+      },
+      _regHints: {
+        securityKey: false,
+        clientDevice: false,
+        hybrid: false,
+        formatted: "[]",
       },
       // Possible values for options.regUserVerification and options.authUserVerification
       userVerificationOpts: [
@@ -458,6 +465,15 @@
       resetSettings() {
         // Reload the page sans query params
         window.location.href = '{% url "index" %}';
+      },
+      handleSelectRegHintsSecurityKey() {
+        this._toggleRegHint('security-key', this._regHints.securityKey);
+      },
+      handleSelectRegHintsClientDevice() {
+        this._toggleRegHint('client-device', this._regHints.clientDevice);
+      },
+      handleSelectRegHintsHybrid() {
+        this._toggleRegHint('hybrid', this._regHints.hybrid);
       },
 
       // Internal Methods
@@ -579,6 +595,25 @@
           window.location.href = '{% url "index" %}';
         } else {
           this.showErrorAlert(`Authentication failed: ${verificationJSON.error}`);
+        }
+      },
+      /**
+       * Registration hints can be ordered by preference, but there's no good native HTML element
+       * that allows for selection _and_ sorting.
+       *
+       * We'll handle it here by making each hint a checkbox, and the order in which a checkbox is
+       * checked will simply append that hint to the end of the list of selected hints.
+       *
+       * Unchecking a hint will remove it from its arbitrary place in the list of choices.
+       */
+      _toggleRegHint(hintName, isChecked) {
+        if (isChecked) {
+          this.options.regHints.push(hintName);
+        } else {
+          const securityKeyIndex = this.options.regHints.indexOf(hintName);
+          if (securityKeyIndex >= 0) {
+            this.options.regHints.splice(securityKeyIndex, 1);
+          }
         }
       },
     }));

--- a/_app/homepage/views/registration_options.py
+++ b/_app/homepage/views/registration_options.py
@@ -29,6 +29,7 @@ def registration_options(request: HttpRequest) -> JsonResponse:
     options_algorithms = form_data["algorithms"]
     options_username = form_data["username"]
     options_discoverable_credential = form_data["discoverable_credential"]
+    options_hints = form_data["hints"]
 
     registration_service = RegistrationService()
     credential_service = CredentialService()
@@ -43,9 +44,13 @@ def registration_options(request: HttpRequest) -> JsonResponse:
             username=options_username
         ),
         discoverable_credential=options_discoverable_credential,
+        hints=options_hints,
     )
 
     options_json = json.loads(options_to_json(registration_options))
+
+    # Tack on hints (till py_webauthn learns about hints and we can handle it in the service)
+    options_json["hints"] = options_hints
 
     # Add in credProps extension
     options_json["extensions"] = {


### PR DESCRIPTION
This PR adds registration hints to the Advanced Settings drawer:

![Screenshot 2024-01-03 at 1 20 00 PM](https://github.com/duo-labs/webauthn.io/assets/5166470/9080b3ea-dccd-4fc5-b654-10068a5fea62)

Hints can be specified from most preferred to least preferred ([L3 draft](https://w3c.github.io/webauthn/#enum-hints)):

> Hints are provided in order of decreasing preference so, if two hints are contradictory, the first one controls.

To help support this on webauthn.io, **the order in which the three checkboxes are checked controls the order of preference:**


https://github.com/duo-labs/webauthn.io/assets/5166470/11cc5ce7-15af-4502-be20-b47e28bd5459

As per L3 as well, **when hints are specified they will override the existing Attachment setting:**

> Hints MAY contradict information contained in credential [transports](https://w3c.github.io/webauthn/#dom-publickeycredentialdescriptor-transports) and [authenticatorAttachment](https://w3c.github.io/webauthn/#dom-authenticatorselectioncriteria-authenticatorattachment). When this occurs, the hints take precedence.

As with other existing options, selected hints and their order of preference are persisted in the URL for ease of sharing configurations.