### PR TITLE
Use python:3.10-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Tweak the base image by installing pipenv
-FROM python:3.10 as base
+FROM python:3.10-slim as base
 RUN pip install pipenv
 
 # Begin our actual build


### PR DESCRIPTION
Building the `django` Docker image was taking too long and outputting massive images. After all of the recent work to simplify the project (#117, #118) I'm finally able to explore smaller Docker images as the base image.

I decided to go with `python:3.10-slim` as it lead to significantly smaller images:

```
REPOSITORY                 TAG             IMAGE ID       CREATED          SIZE
webauthnio-django-slim     latest          20d8441331d2   8 seconds ago    279MB
webauthnio-django          latest          75667dbb7c29   42 seconds ago   1.13GB
```

No changes in behavior have been observed so I'm going ahead with this.