### PR TITLE
fix/csrf-issues-march-2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run the following command to get started:
 $> ./start-dev.sh
 ```
 
-The site will be available at https://localhost
+The site will be available at http://localhost/
 
 ### CSS
 

--- a/_app/webauthnio/settings.py
+++ b/_app/webauthnio/settings.py
@@ -13,7 +13,7 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 DEBUG = os.getenv("DEBUG", False) == "true"
 
 ALLOWED_HOSTS = ["localhost"]
-CSRF_TRUSTED_ORIGINS = ["https://localhost"]
+CSRF_TRUSTED_ORIGINS = ["http://localhost"]
 
 # Should include protocol (e.g. "https://webauthn.io", "http://localhost")
 PROD_HOST_NAME = os.getenv("PROD_HOST_NAME", None)

--- a/_app/webauthnio/settings.py
+++ b/_app/webauthnio/settings.py
@@ -15,12 +15,16 @@ DEBUG = os.getenv("DEBUG", False) == "true"
 ALLOWED_HOSTS = ["localhost"]
 CSRF_TRUSTED_ORIGINS = ["http://localhost"]
 
-# Should include protocol (e.g. "https://webauthn.io", "http://localhost")
+# MUST NOT include protocol (e.g. "webauthn.io")
 PROD_HOST_NAME = os.getenv("PROD_HOST_NAME", None)
+# MUST include protocol (e.g. "https://webauthn.io")
+PROD_CSRF_ORIGIN = os.getenv("PROD_CSRF_ORIGIN", None)
 
-if PROD_HOST_NAME:
+if PROD_HOST_NAME and PROD_CSRF_ORIGIN:
+    # e.g. "webauthn.io"
     ALLOWED_HOSTS.append(PROD_HOST_NAME)
-    CSRF_TRUSTED_ORIGINS.append(PROD_HOST_NAME)
+    # e.g. "https://webauthn.io"
+    CSRF_TRUSTED_ORIGINS.append(PROD_CSRF_ORIGIN)
 
 # Application definition
 

--- a/_caddy/Caddyfile
+++ b/_caddy/Caddyfile
@@ -1,4 +1,4 @@
-{$PROD_HOST_NAME}
+{$PROD_CSRF_ORIGIN}
 
 route {
   file_server /static/* {

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,7 @@ services:
   caddy:
     environment:
       # Site will be available at http://localhost
-      - PROD_HOST_NAME=http://localhost
+      - PROD_CSRF_ORIGIN=http://localhost
 
   redis:
     ports:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ version: '3.5'
 services:
   caddy:
     environment:
-      # Site will be available at https://localhost
+      # Site will be available at http://localhost
       - PROD_HOST_NAME=http://localhost
 
   redis:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -19,3 +19,5 @@ services:
       - RP_ID=localhost
       - RP_NAME=WebAuthn.io (Dev)
       - RP_EXPECTED_ORIGIN=http://localhost
+      - PROD_HOST_NAME=
+      - PROD_CSRF_ORIGIN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     networks:
       - caddy_network
     environment:
-      - PROD_HOST_NAME
+      - PROD_CSRF_ORIGIN
 
   django:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - PYTHONUNBUFFERED=0
       - DJANGO_SECRET_KEY
       - PROD_HOST_NAME
+      - PROD_CSRF_ORIGIN
       - RP_ID
       - RP_NAME
       - RP_EXPECTED_ORIGIN


### PR DESCRIPTION
This PR adds a new `PROD_CSRF_ORIGIN` env var that helps me define two slightly different values: one for the allowed production hostname, and one for the valid CSRF production origin. The values are slightly different and using the same value for both gets messy especially since I want Caddy to only host over `https://` in production (which should be the same as the valid CSRF origin.)

Fixes #131.