### PR TITLE
Remove admin panel URLs

### DIFF
--- a/_app/webauthnio/urls.py
+++ b/_app/webauthnio/urls.py
@@ -13,7 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
+
 from django.urls import path, include
 
-urlpatterns = [path("admin/", admin.site.urls), path("", include("homepage.urls"))]
+urlpatterns = [
+    path("", include("homepage.urls")),
+]


### PR DESCRIPTION
This PR removes the `admin/` routes because the admin panel isn't used for anything right now.