### PR TITLE
Reset conditional UI on auth UV change

### DIFF
--- a/_app/homepage/static/css/index.css
+++ b/_app/homepage/static/css/index.css
@@ -608,3 +608,13 @@ footer {
     }
   }
 }
+
+#advanced-settings-tips-tricks {
+  &[open]::backdrop {
+    background-color: rgb(0 0 0 / 25%);
+  }
+
+  body:has(&[open]) {
+    overflow: hidden;
+  }
+}

--- a/_app/homepage/static/css/index.css
+++ b/_app/homepage/static/css/index.css
@@ -610,6 +610,8 @@ footer {
 }
 
 #advanced-settings-tips-tricks {
+  max-width: 42em;
+
   &[open]::backdrop {
     background-color: rgb(0 0 0 / 25%);
   }

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -254,12 +254,30 @@
                 <button class="btn btn-warning" @click="resetSettings()">
                   Reset Settings
                 </button>
+                <button
+                  id="advanced-settings-tips-tricks-open"
+                  class="btn btn-link float-right"
+                  @click="openTipsTricks()"
+                >
+                  (tips &amp; tricks)
+                </button>
               </section>
             </div>
 
           </div>
         </div>
       </div>
+      <dialog id="advanced-settings-tips-tricks">
+        <h1>Hello</h1>
+        <button
+          id="advanced-settings-tips-tricks-close"
+          class="btn btn-primary"
+          @click="closeTipsTricks()"
+          autofocus
+        >
+          Close
+        </button>
+      </dialog>
     </section>
   </template>
 
@@ -491,7 +509,13 @@
       handleSelectRegHintsHybrid() {
         this._toggleRegHint('hybrid', this._regHints.hybrid);
       },
-
+      // Tips & Tricks Modal
+      openTipsTricks() {
+        document.getElementById('advanced-settings-tips-tricks').showModal();
+      },
+      closeTipsTricks() {
+        document.getElementById('advanced-settings-tips-tricks').close();
+      },
       // Internal Methods
       async _startRegistration() {
         // Submit options

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -268,7 +268,24 @@
         </div>
       </div>
       <dialog id="advanced-settings-tips-tricks">
-        <h1>Hello</h1>
+        <p class="h5">Advanced Settings Tips & Tricks</p>
+        <p>
+          A brief list of advanced capabilities that may not be immediately obvious when using this site:
+        </p>
+        <ul>
+          <li>
+            <strong>Sharing the URL</strong> in the address bar after making changes in Advanced Settings enables
+            others to open this site with the same configuration.
+          </li>
+          <li>
+            Clicking <strong>Authenticate</strong> without entering a username is supported. This
+            enables testing "usernameless" authentication.
+          </li>
+          <li>
+            Changing <strong>Authentication Settings > User Verification</strong> will restart
+            conditional UI using the chosen setting.
+          </li>
+        </ul>
         <button
           id="advanced-settings-tips-tricks-close"
           class="btn btn-primary"

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -379,21 +379,7 @@
           this._formatRegHintsForUI();
         });
 
-        // Set up Conditional UI if supported
-        browserSupportsWebAuthnAutofill().then(async (supported) => {
-          if (supported) {
-            console.log('Setting up Conditional UI');
-            try {
-              await this._startAuthentication(true);
-            } catch (err) {
-              if (err.name === 'AbortError') {
-                console.log('Conditional UI request was aborted');
-              } else {
-                console.error('Conditional UI error:', err);
-              }
-            }
-          }
-        });
+        this._startConditionalUI();
       },
 
       // Default state
@@ -628,6 +614,23 @@
         } else {
           this.showErrorAlert(`Authentication failed: ${verificationJSON.error}`);
         }
+      },
+      async _startConditionalUI() {
+        // Set up Conditional UI if supported
+        browserSupportsWebAuthnAutofill().then(async (supported) => {
+          if (supported) {
+            console.log('Setting up Conditional UI');
+            try {
+              await this._startAuthentication(true);
+            } catch (err) {
+              if (err.name === 'AbortError') {
+                console.log('Conditional UI request was aborted');
+              } else {
+                console.error('Conditional UI error:', err);
+              }
+            }
+          }
+        });
       },
       /**
        * Registration hints can be ordered by preference, but there's no good native HTML element

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -379,6 +379,13 @@
           this._formatRegHintsForUI();
         });
 
+        /**
+         * Restart conditional UI when auth UV setting changes
+         */
+        this.$watch('options.authUserVerification', () => {
+          this._startConditionalUI();
+        });
+
         this._startConditionalUI();
       },
 


### PR DESCRIPTION
This PR enhances the site's ability to test conditional UI by restarting conditional UI whenever **Advanced Settings > Authentication Settings > User Verification** is changed:

![Screenshot 2024-11-22 at 12 13 50 PM](https://github.com/user-attachments/assets/b6245bf5-5364-41f8-b8c5-66eb09de832f)

A helpful "tips & tricks" modal has also been added to communicate some of the more advanced functionality that's been lurking around the site:

![Screenshot 2024-11-22 at 12 11 30 PM](https://github.com/user-attachments/assets/3d6b66dd-3eca-40be-bd7c-858008385c7b)
