### PR TITLE
Add back-button to support to profile.html

### DIFF
--- a/_app/homepage/templates/homepage/profile.html
+++ b/_app/homepage/templates/homepage/profile.html
@@ -96,4 +96,12 @@
     </div>
   </div>
 </section>
+<script>
+  // Small quirk: Users pressing the back button likels wants to be signed out to sign in again.
+  window.history.pushState({ page: 'profile' }, '', window.location.href);
+
+  window.addEventListener('popstate', function(event) {
+      window.location.href = '/logout';
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
Hey!

I've been caught one too may times pressing the back button and ending up at google or whatever I visited before going to webauthn.io. This would keep the same "no additional /profile" pattern, but sign the user out and redirect back to the homepage when they press the browser back button.

Note: I just whipped this out in the browser, so I haven't executed the code to verify it works.

