### PR TITLE
feat/152-authentication-hints

### DIFF
--- a/_app/homepage/forms.py
+++ b/_app/homepage/forms.py
@@ -62,6 +62,14 @@ class AuthenticationOptionsRequestForm(forms.Form):
             ("required", "Required"),
         ],
     )
+    hints = forms.MultipleChoiceField(
+        required=False,
+        choices=[
+            ("security-key", "Security Key"),
+            ("client-device", "Client Device"),
+            ("hybrid", "Hybrid"),
+        ],
+    )
 
 
 class AuthenticationResponseForm(forms.Form):

--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -261,6 +261,51 @@
                   </template>
                 </select>
               </label>
+
+              <!-- Authentication Hints -->
+              <section class="col-sm-12 mb-2">
+                <p class="mb-0">Authentication Hints (most to least preferred)</p>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    class="custom-control-input"
+                    id="authHintSecurityKey"
+                    x-model="_authHints.securityKey"
+                    @change="handleSelectAuthHintsSecurityKey"
+                  />
+                  <label class="custom-control-label" for="authHintSecurityKey">
+                    Security Key
+                  </label>
+                </div>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    class="custom-control-input"
+                    id="authHintClientDevice"
+                    x-model="_authHints.clientDevice"
+                    @change="handleSelectAuthHintsClientDevice"
+                  />
+                  <label class="custom-control-label" for="authHintClientDevice">
+                    Client Device
+                  </label>
+                </div>
+                <div class="custom-control custom-checkbox custom-control-inline">
+                  <input
+                    type="checkbox"
+                    class="custom-control-input"
+                    id="authHintHybrid"
+                    x-model="_authHints.hybrid"
+                    @change="handleSelectAuthHintsHybrid"
+                  />
+                  <label class="custom-control-label" for="authHintHybrid">
+                    Hybrid
+                  </label>
+                </div>
+                <p class="mb-0 text-secondary">
+                  Order:
+                  <span x-text="_authHints.formatted"></span>
+                </p>
+              </section>
             </div>
 
             <div class="row">
@@ -410,6 +455,21 @@
               break;
             }
           }
+
+          const _authHintsStr = currentParams.get('authHints');
+          _authHintsStr.split(',').forEach((hint) => {
+            if (hint === 'security-key') {
+              this._authHints.securityKey = true;
+              this._toggleAuthHint('security-key', true);
+            } else if (hint === 'client-device') {
+              this._authHints.clientDevice = true;
+              this._toggleAuthHint('client-device', true);
+            } else if (hint === 'hybrid') {
+              this._authHints.hybrid = true;
+              this._toggleAuthHint('hybrid', true);
+            }
+          });
+          this._formatAuthHintsForUI();
         }
 
         // Update query parameters when options change
@@ -427,6 +487,13 @@
          */
         this.$watch('options.regHints', () => {
           this._formatRegHintsForUI();
+        });
+
+        /**
+         * Format the list of authentication hints to help confirm the order of preference
+         */
+        this.$watch('options.authHints', () => {
+          this._formatAuthHintsForUI();
         });
 
         /**
@@ -455,6 +522,7 @@
         regHints: [],
         // Authentication
         authUserVerification: 'preferred',
+        authHints: [],
       },
       username: '',
       alert: {
@@ -464,6 +532,12 @@
       },
       // We need to track some state to properly support hints preference order
       _regHints: {
+        securityKey: false,
+        clientDevice: false,
+        hybrid: false,
+        formatted: "[]",
+      },
+      _authHints: {
         securityKey: false,
         clientDevice: false,
         hybrid: false,
@@ -541,6 +615,15 @@
       },
       handleSelectRegHintsHybrid() {
         this._toggleRegHint('hybrid', this._regHints.hybrid);
+      },
+      handleSelectAuthHintsSecurityKey() {
+        this._toggleAuthHint('security-key', this._authHints.securityKey);
+      },
+      handleSelectAuthHintsClientDevice() {
+        this._toggleAuthHint('client-device', this._authHints.clientDevice);
+      },
+      handleSelectAuthHintsHybrid() {
+        this._toggleAuthHint('hybrid', this._authHints.hybrid);
       },
       // Tips & Tricks Modal
       openTipsTricks() {
@@ -637,6 +720,7 @@
 
         const {
           authUserVerification,
+          authHints,
         } = this.options;
 
         let username = this.username;
@@ -652,6 +736,7 @@
           body: JSON.stringify({
             username,
             user_verification: authUserVerification,
+            hints: authHints,
           }),
         });
         const authenticationOptionsJSON = await apiAuthOptsResp.json();
@@ -736,6 +821,35 @@
         formattedHints = formattedHints.replace(/,/g, ", ");
 
         this._regHints.formatted = formattedHints;
+      },
+      /**
+       * Authentication hints can be ordered by preference, but there's no good native HTML element
+       * that allows for selection _and_ sorting.
+       *
+       * We'll handle it here by making each hint a checkbox, and the order in which a checkbox is
+       * checked will simply append that hint to the end of the list of selected hints.
+       *
+       * Unchecking a hint will remove it from its arbitrary place in the list of choices.
+       */
+       _toggleAuthHint(hintName, isChecked) {
+        if (isChecked) {
+          this.options.authHints.push(hintName);
+        } else {
+          const hintIndex = this.options.authHints.indexOf(hintName);
+          if (hintIndex >= 0) {
+            this.options.authHints.splice(hintIndex, 1);
+          }
+        }
+      },
+      /**
+       * Format registration hints so we can visualize their preference order
+       */
+       _formatAuthHintsForUI() {
+        let formattedHints = JSON.stringify(this.options.authHints);
+        // Add a space between items
+        formattedHints = formattedHints.replace(/,/g, ", ");
+
+        this._authHints.formatted = formattedHints;
       },
       /**
        * If the user hits the browser back button from the profile page then the input can still

--- a/_app/homepage/views/authentication_options.py
+++ b/_app/homepage/views/authentication_options.py
@@ -3,6 +3,7 @@ import json
 from django.http import JsonResponse, HttpRequest
 from django.views.decorators.csrf import csrf_exempt
 from webauthn import options_to_json
+from webauthn.helpers.structs import PublicKeyCredentialHint
 
 from homepage.services import AuthenticationService, CredentialService, SessionService
 from homepage.forms import AuthenticationOptionsRequestForm
@@ -21,6 +22,7 @@ def authentication_options(request: HttpRequest) -> JsonResponse:
     form_data = options_form.cleaned_data
     options_username: str | None = form_data["username"]
     options_user_verification = form_data["user_verification"]
+    options_hints = form_data["hints"]
 
     authentication_service = AuthenticationService()
     session_service = SessionService()
@@ -41,4 +43,10 @@ def authentication_options(request: HttpRequest) -> JsonResponse:
         existing_credentials=existing_credentials,
     )
 
-    return JsonResponse(json.loads(options_to_json(authentication_options)))
+    options_json_str = options_to_json(authentication_options)
+    options_json = json.loads(options_json_str)
+
+    # Map hints here (py_webauthn doesn't yet recognize auth hints)
+    options_json["hints"] = [PublicKeyCredentialHint(hint) for hint in options_hints]
+
+    return JsonResponse(options_json)


### PR DESCRIPTION
This PR adds support for specifying hints during authentication. The experience is the same as registration hints:

- Checking a hint adds it to the end of the list
- Unchecking a hint removes it from wherever it is in the list

Fixes #152.

## Screenshots

![Screenshot 2025-02-19 at 4 26 27 PM](https://github.com/user-attachments/assets/17e4d074-cf17-41d3-94cf-0286708a2215)