### PR TITLE
fix: ensure that all containers are always restarted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-version: '3.5'
+version: "3.5"
 
 services:
   redis:
+    restart: unless-stopped
     image: redis:6.2.6
     networks:
       - redis_network
@@ -24,6 +25,7 @@ services:
       - PROD_CSRF_ORIGIN
 
   django:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   redis:
     restart: unless-stopped


### PR DESCRIPTION
Currently only the `caddy` container will start again if the underlying instance that the docker containers are running on is deleted.

This PR ensures all of them start again when the underlying instance is restarted.

I've also removed the version section as that's not required anymore, [see here](https://docs.docker.com/reference/compose-file/version-and-name/).