### PR TITLE
Use Docker's secrets support to project DJANGO_SECRET_KEY

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
     - name: Write Docker-secrets-like file for CI
       run: |
-        touch /run/secrets/django_secret_key
+        mkdir -p /run/secrets && touch /run/secrets/django_secret_key
         echo "for-testing-only" > /run/secrets/django_secret_key
 
     - uses: actions/checkout@v5

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -32,6 +32,7 @@ jobs:
     steps:
     - name: Write Docker-secrets-like file for CI
       run: |
+        touch /run/secrets/django_secret_key
         echo "for-testing-only" > /run/secrets/django_secret_key
 
     - uses: actions/checkout@v5

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      DJANGO_SECRET_KEY: for-testing-only
+      DJANGO_SECRET_KEY_FILE: ${{ runner.temp }}/django_secret_key
     strategy:
       matrix:
         python-version: ['3.10']
@@ -32,8 +32,7 @@ jobs:
     steps:
     - name: Write Docker-secrets-like file for CI
       run: |
-        mkdir -p /run/secrets && touch /run/secrets/django_secret_key
-        echo "for-testing-only" > /run/secrets/django_secret_key
+        echo "for-testing-only" > $DJANGO_SECRET_KEY_FILE
 
     - uses: actions/checkout@v5
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -10,8 +10,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    env:
-      DJANGO_SECRET_KEY_FILE: ${{ runner.temp }}/django_secret_key
     strategy:
       matrix:
         python-version: ['3.10']
@@ -30,10 +28,6 @@ jobs:
           - 6379:6379
 
     steps:
-    - name: Write Docker-secrets-like file for CI
-      run: |
-        echo "for-testing-only" > $DJANGO_SECRET_KEY_FILE
-
     - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
@@ -49,11 +43,15 @@ jobs:
     - name: Install dependencies
       run: uv sync --locked --all-extras --dev
 
+    - name: Create Docker-secrets-like file for Django to read
+      run: echo "for-testing-only" > ${{ runner.temp }}/django_secret_key
+
     - name: Test with unittest
       run: uv run python _app/manage.py test homepage.tests
       env:
         # Tests are running "locally" while Redis is in a container
         REDIS_HOSTNAME: localhost
+        DJANGO_SECRET_KEY_FILE: ${{ runner.temp }}/django_secret_key
 
     - name: Run mypy
       run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -30,6 +30,10 @@ jobs:
           - 6379:6379
 
     steps:
+    - name: Write Docker-secrets-like file for CI
+      run: |
+        echo "for-testing-only" > /run/secrets/django_secret_key
+
     - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ WORKDIR /usr/src/app
 RUN uv sync --locked
 
 # Collect static files
-RUN --mount=type=secret,id=django_secret_key,required=true uv run python manage.py collectstatic --no-input
+RUN --mount=type=secret,id=django_secret_key,required=true \
+DJANGO_SECRET_KEY_FILE=/run/secrets/django_secret_key uv run python manage.py collectstatic --no-input

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Tweak the base image by installing uv
 FROM python:3.10-slim AS base
 
@@ -6,9 +8,6 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
 
 # Begin our actual build
 FROM base AS base1
-# collectstatic needs the secret key to be set. We store that in this environment variable.
-# Set this value in this project's .env file
-ARG DJANGO_SECRET_KEY
 
 RUN mkdir -p /usr/src/app
 
@@ -21,4 +20,4 @@ WORKDIR /usr/src/app
 RUN uv sync --locked
 
 # Collect static files
-RUN uv run python manage.py collectstatic --no-input
+RUN --mount=type=secret,id=django_secret_key,required=true uv run python manage.py collectstatic --no-input

--- a/_app/webauthnio/settings.py
+++ b/_app/webauthnio/settings.py
@@ -4,9 +4,13 @@ import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Read the secret from the file that Docker injects
-# (see https://docs.docker.com/reference/compose-file/build/#secrets)
-_secret_key_file = open("/run/secrets/django_secret_key", "r")
+# Get path to the file containing the secret (this is a Docker-specific method)
+_secret_key_file_path = os.getenv("DJANGO_SECRET_KEY_FILE")
+if not _secret_key_file_path:
+    raise Exception("DJANGO_SECRET_KEY_FILE must be a file path string")
+
+# Read the secret from the file
+_secret_key_file = open(_secret_key_file_path, "r")
 SECRET_KEY = _secret_key_file.read()
 _secret_key_file.close()
 

--- a/_app/webauthnio/settings.py
+++ b/_app/webauthnio/settings.py
@@ -4,7 +4,7 @@ import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-# Get path to the file containing the secret (this is a Docker-specific method)
+# Get the path to the file containing the secret
 _secret_key_file_path = os.getenv("DJANGO_SECRET_KEY_FILE")
 if not _secret_key_file_path:
     raise Exception("DJANGO_SECRET_KEY_FILE must be a file path string")

--- a/_app/webauthnio/settings.py
+++ b/_app/webauthnio/settings.py
@@ -4,12 +4,13 @@ import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Read the secret from the file that Docker injects
+# (see https://docs.docker.com/reference/compose-file/build/#secrets)
+_secret_key_file = open("/run/secrets/django_secret_key", "r")
+SECRET_KEY = _secret_key_file.read()
+_secret_key_file.close()
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
-
-SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
-
+# Enable doing things differently if we're in debug mode
 DEBUG = os.getenv("DEBUG", False) == "true"
 
 ALLOWED_HOSTS = ["localhost"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,10 @@ services:
     networks:
       - caddy_network
       - redis_network
+    secrets:
+      - django_secret_key
     environment:
       - PYTHONUNBUFFERED=0
-      - DJANGO_SECRET_KEY
       - PROD_HOST_NAME
       - PROD_CSRF_ORIGIN
       - RP_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,3 +61,7 @@ volumes:
 networks:
   caddy_network:
   redis_network:
+
+secrets:
+  django_secret_key:
+    environment: DJANGO_SECRET_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       - django_secret_key
     environment:
       - PYTHONUNBUFFERED=0
+      - DJANGO_SECRET_KEY_FILE=/run/secrets/django_secret_key
       - PROD_HOST_NAME
       - PROD_CSRF_ORIGIN
       - RP_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        - DJANGO_SECRET_KEY
+      secrets:
+        - django_secret_key
     depends_on:
       - redis
     command: uv run gunicorn webauthnio.wsgi -c gunicorn.cfg.py


### PR DESCRIPTION
This PR uses [Docker Compose's `secrets` attribute](https://docs.docker.com/reference/compose-file/secrets/) to prevent the `DJANGO_SECRET_KEY` value from being output in plaintext at build time. This occurred because of the use of `ARG DJANGO_SECRET_KEY` in **Dockerfile**.

For comparison, here's the change in build output as viewed in Docker Desktop:

## Before

<img width="841" height="386" alt="Screenshot 2025-11-21 at 4 04 54 PM" src="https://github.com/user-attachments/assets/c64c84ad-2f6a-4bbf-8827-944fb806fb5e" />

## After

<img width="826" height="331" alt="Screenshot 2025-11-21 at 4 43 53 PM" src="https://github.com/user-attachments/assets/6ff43e15-c9d0-446b-8656-9a23719754b4" />