### PR TITLE
Add w3pk TypeScript library to homepage examples

### DIFF
--- a/_app/homepage/const.py
+++ b/_app/homepage/const.py
@@ -35,6 +35,13 @@ libraries = [
         type="Library",
     ),
     WebAuthnExample(
+        language="TypeScript",
+        url="https://github.com/w3hc/w3pk",
+        title="w3pk",
+        author="Julien Béranger",
+        type="Library",
+    ),
+    WebAuthnExample(
         language="Ruby",
         url="https://github.com/cedarcode/webauthn-ruby",
         title="cedarcode/webauthn-ruby",


### PR DESCRIPTION
## Summary
- Added [w3pk](https://github.com/w3hc/w3pk) TypeScript library to the libraries list on the homepage

## Changes
- Added w3pk entry in `_app/homepage/const.py` with library details

## Result
The w3pk library now appears on the webauthn.io homepage alongside other TypeScript WebAuthn libraries like SimpleWebAuthn and passwordless-id/webauthn.