### PR TITLE
Disable autocapitalize and autocorrect on login form

### DIFF
--- a/_app/homepage/templates/homepage/sections/webauthn_form.html
+++ b/_app/homepage/templates/homepage/sections/webauthn_form.html
@@ -13,6 +13,8 @@
               placeholder="example_username"
               x-model="username"
               autocomplete="username webauthn"
+              autocapitalize="off"
+              autocorrect="off"
               autofocus
               @input.debounce="handleSaveUsername"
             />


### PR DESCRIPTION
Since the username is case sensitive, allowing the phone keyboard to auto capitalize the first char is not ideal, although it doesn't matter unless you first register on PC and then try it on your phone.   And autocorrect for that field is just bad :P  
  
References:  
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocorrect
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocapitalize