### PR TITLE
fix: use compose v2 in deploy scripts and stop nuking caddy_data on update

### DIFF
--- a/start-prod.sh
+++ b/start-prod.sh
@@ -1,1 +1,1 @@
-docker-compose -f docker-compose.yml up -d
+docker compose -f docker-compose.yml up -d

--- a/update-prod-django.sh
+++ b/update-prod-django.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
+set -euo pipefail
+
 echo "[START]"
 echo "---stopping django and caddy---"
-docker-compose stop django caddy
+docker compose stop django caddy
 echo "---removing containers---"
-docker-compose rm -f
-echo "---removing stale volumes---"
-docker volume prune -f
+docker compose rm -f django caddy
 echo "---rebuilding django---"
-docker-compose build django
+docker compose build django
 echo "---restarting django and caddy---"
-docker-compose -f docker-compose.yml up -d --no-deps django caddy
+docker compose -f docker-compose.yml up -d --no-deps django caddy
 echo "[END]"


### PR DESCRIPTION
## Why

Two small ops papercuts in the production deploy scripts. None affect the app — only how it's brought up.

## Changes (2 files, +7 / −7)

- **`start-prod.sh` / `update-prod-django.sh`** — `docker-compose` → `docker compose` (v2). `docker-compose` v1 is EOL and emits legacy compose-spec warnings on hosts shipping Compose v2 (AL2023, Debian 12, recent Ubuntu).
- **`update-prod-django.sh`** — add `set -euo pipefail` so a failed step halts the script instead of leaving the stack half-stopped. Scope `compose rm -f` to `django caddy` (was unscoped, would also remove the running `redis`).
- **`update-prod-django.sh`** — drop `docker volume prune -f`. It was deleting the `caddy_data` named volume on every deploy, forcing Let's Encrypt re-issuance and risking rate limits.

The `redis_network` / `caddy_network` split is intentionally preserved — it keeps `caddy` unable to reach `redis` directly (no shared network), which is real defense-in-depth even though caddy has no code path that would talk to redis today. (Thanks @mattmil3 for catching that the earlier revision of this PR removed it.)

## Test

```sh
docker compose config --quiet
docker compose down && docker compose up -d
./update-prod-django.sh
curl -sI https://<host>/
```

Verified on AL2023 + Docker 26 + Compose v2.